### PR TITLE
use unauthenticated proxy for electron project

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,17 @@ const path = require('path')
 
 async function getCrowdinFileIds (project, crowdinKey) {
   crowdinKey = crowdinKey || process.env.CROWDIN_KEY
+  let url
 
   assert(project, '`project` must be the first argument')
-  assert(crowdinKey, '`crowdinKey` must be the second argument or process.env.CROWDIN_KEY')
 
-  const url = `https://api.crowdin.com/api/project/${project}/info?key=${crowdinKey}&json`
+  if (project === 'electron') {
+    url = 'https://electronjs.org/crowdin/info'
+  } else {
+    assert(crowdinKey, '`crowdinKey` must be the second argument or process.env.CROWDIN_KEY')
+    url = `https://api.crowdin.com/api/project/${project}/info?key=${crowdinKey}&json`
+  }
+
   const res = await post(url, {json: true})
   return resolveFile({}, res.body.files)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -15,11 +15,11 @@ describe('getCrowdinFileIds', () => {
   })
 
   it('expects project name and Crowdin API key as arguments', async () => {
-    crowdin.post('/project/electron/info?key=xyz&json')
+    crowdin.post('/project/foo-project/info?key=xyz&json')
       .once()
       .reply(200, require('./fixture.json'))
 
-    const urls = await getCrowdinFileIds('electron', 'xyz')
+    const urls = await getCrowdinFileIds('foo-project', 'xyz')
     const paths = Object.keys(urls)
 
     urls.should.be.an('object')
@@ -30,7 +30,17 @@ describe('getCrowdinFileIds', () => {
   })
 
   it('falls back to CROWDIN_KEY env var', async () => {
-    crowdin.post('/project/electron/info?key=abc&json')
+    crowdin.post('/project/bar-project/info?key=abc&json')
+      .once()
+      .reply(200, require('./fixture.json'))
+
+    const urls = await getCrowdinFileIds('bar-project')
+    urls.should.be.an('object')
+  })
+
+  it('uses the unauthenticated website proxy for the `electron` project', async () => {
+    nock('https://electronjs.org/crowdin')
+      .post('/info')
       .once()
       .reply(200, require('./fixture.json'))
 


### PR DESCRIPTION
This PR special-cases the `electron` Crowdin project, getting the API data from the [electronjs.org Crowdin proxy](https://github.com/electron/electronjs.org/pull/939). This will enable the module to be used in electron-i18n without requiring the `CROWDIN_KEY` API token.

cc @vanessayuenn @pierreneter 